### PR TITLE
Update/global

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2021": true,
+        "jest": true
     },
     "extends": [
         "plugin:react/recommended",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
-        "@testing-library/dom": "^8.12.0",
+        "@testing-library/dom": "^8.13.0",
         "babel-loader": "^8.2.4",
         "css-loader": "^6.7.1",
         "eslint": "^8.12.0",
@@ -2714,9 +2714,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.12.0.tgz",
-      "integrity": "sha512-rBrJk5WjI02X1edtiUcZhgyhgBhiut96r5Jp8J5qktKdcvLcZpKDW8i2hkGMMItxrghjXuQ5AM6aE0imnFawaw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -15268,9 +15268,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.12.0.tgz",
-      "integrity": "sha512-rBrJk5WjI02X1edtiUcZhgyhgBhiut96r5Jp8J5qktKdcvLcZpKDW8i2hkGMMItxrghjXuQ5AM6aE0imnFawaw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "version": "1.0.0",
   "description": "Front-End Capstone project at Hack Reactor RFP2202 with Alison Lee, Chris Padovan, Edgar Carrillo, and Elbert Chan",
   "main": "index.js",
+  "jest": {
+    "testEnvironment": "jsdom"
+  },
   "scripts": {
     "start": "nodemon server/index.js",
     "dev:react": "webpack --config ./webpack.config.js --mode development --watch",
     "dev:webpack": "webpack-dev-server --mode development --open --hot",
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -20,6 +24,9 @@
   },
   "homepage": "https://github.com/Mob-Psycho-100/project-atelier#readme",
   "dependencies": {
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^14.0.4",
     "axios": "^0.26.1",
     "prop-types": "^15.8.1",
     "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
-    "@testing-library/dom": "^8.12.0",
+    "@testing-library/dom": "^8.13.0",
     "babel-loader": "^8.2.4",
     "css-loader": "^6.7.1",
     "eslint": "^8.12.0",


### PR DESCRIPTION
Adds 3 jest libraries to dependencies. and 1 test srcipt.

    "@testing-library/jest-dom": "^5.16.4",
    "@testing-library/react": "^12.1.2",
    "@testing-library/user-event": "^14.0.4",
    
This also installs react testing library 12.1.2 instead of 13.0.0 since the newer version for some reason doesn't run tests well.

All you need to do is start up create a test file using the following syntax for the file `filename.test.jsx` if testing react or `filename.test.js` if testing pure javascript then run `npm test` or `npm run test` to get your tests running.

I recommend checking this article out to see how to write tests for react. This article is from the offical react-testing-library documentation.

https://www.robinwieruch.de/react-testing-library/

And this article for running pure javascript tests.

https://jestjs.io/docs/getting-started