### PR TITLE
Feat/overview/addtocart

### DIFF
--- a/react-client/src/components/Overview/AddToCart/AddToCartBtn.jsx
+++ b/react-client/src/components/Overview/AddToCart/AddToCartBtn.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+import plusSignSrc from './plus-sign-icon.svg';
+
+function AddToCartBtn({ className, actionHandler }) {
+  return <button className={className} type="submit" onClick={(e) => actionHandler(e)}>Add to Cart</button>;
+}
+
+AddToCartBtn.propTypes = {
+  className: propTypes.string.isRequired,
+  actionHandler: propTypes.func.isRequired,
+};
+
+const StyledAddToCartBtn = styled(AddToCartBtn)`
+  ${({ hasStylesInStock }) => !hasStylesInStock && 'display: none;'}
+  font-family: var(--fnt-bold);
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  height: 65px;
+  width: 300px;
+  background-image: url("${plusSignSrc}");
+  background-repeat: no-repeat;
+  background-position: calc(100% - 10px);
+  background-size: 15px;
+  background-color: var(--clr-white);
+  border: 1px solid var(--clr-light-grey);
+  text-align: left;
+  padding: 0 10px;
+  cursor: pointer;
+  flex-grow: 1;
+`;
+
+export default StyledAddToCartBtn;

--- a/react-client/src/components/Overview/AddToCart/AddToCartContainer.jsx
+++ b/react-client/src/components/Overview/AddToCart/AddToCartContainer.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+// Components
+import StyledSelectSize from './SelectSize.jsx';
+import QtySelector from './QtySelector.jsx';
+import StyledAddToCartBtn from './AddToCartBtn.jsx';
+import StyledAlert from './Alert.jsx';
+
+function AddToCartContainer({ className, items }) {
+  const [selectedItem, setSelectedItem] = useState({ stock: 0 });
+  const [userSelection, setUserSelection] = useState({ size: '', qty: '0' });
+  const [alertVisible, setAlertVisible] = useState(false);
+  const hasStylesInStock = items.some((item) => item.stock > 0);
+
+  const updateSelectedItem = (id) => {
+    if (selectedItem.id !== id) {
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].id === id) {
+          setSelectedItem(items[i]);
+          break;
+        }
+      }
+    }
+  };
+
+  const changeUserSize = (size) => {
+    const newUserSelection = { ...userSelection };
+    newUserSelection.size = size;
+    newUserSelection.qty = String(1);
+    setUserSelection(newUserSelection);
+  };
+
+  const changeUserQty = (qty) => {
+    const newUserSelection = { ...userSelection };
+    newUserSelection.qty = qty;
+    setUserSelection(newUserSelection);
+  };
+
+  const getSize = (id) => {
+    const { value } = items.filter((item) => item.id === id)[0];
+    return value;
+  };
+
+  const showAlert = () => {
+    setAlertVisible(true);
+  };
+
+  const hideAlert = () => {
+    setAlertVisible(false);
+  };
+
+  return (
+    <div>
+      <StyledAlert text="Please select size." isVisible={alertVisible} />
+      <div className={className}>
+        <StyledSelectSize
+          selections={items}
+          selectHandler={(e) => {
+            if (alertVisible) {
+              hideAlert(false);
+            }
+            changeUserSize(getSize(e.target.value));
+            updateSelectedItem(e.target.value);
+          }}
+        />
+        <QtySelector
+          qty={selectedItem.stock}
+          clickHandler={changeUserQty}
+          userQty={userSelection.qty}
+        />
+        <StyledAddToCartBtn
+          hasStylesInStock={hasStylesInStock}
+          actionHandler={() => {
+            const { size, qty } = userSelection;
+
+            if (size.length > 0 && Number(qty) > 0) {
+              console.log('Ready to submit! Here is the data: ', userSelection);
+            } else {
+              showAlert();
+            }
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+AddToCartContainer.propTypes = {
+  className: propTypes.string.isRequired,
+  items: propTypes.arrayOf(propTypes.shape({
+    id: propTypes.string.isRequired,
+    value: propTypes.string.isRequired, // The size of the product (large, medium, etc.)
+    stock: propTypes.number.isRequired, // the amount of the product in stock.
+  })).isRequired,
+};
+
+const StyledAddToCartContainer = styled(AddToCartContainer)`
+  display: flex;
+  justify-content: space-between;
+  gap: 30px;
+  flex-wrap: wrap;
+  max-width: 450px;
+`;
+
+export default StyledAddToCartContainer;

--- a/react-client/src/components/Overview/AddToCart/Alert.jsx
+++ b/react-client/src/components/Overview/AddToCart/Alert.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+function Alert({ className, text }) {
+  return <p className={className}>{text}</p>;
+}
+
+Alert.propTypes = {
+  className: propTypes.string.isRequired,
+  text: propTypes.string.isRequired,
+};
+
+const StyledAlert = styled(Alert)`
+  display: none;
+  ${(({ isVisible }) => isVisible && 'display: inline-block;')}
+  font-family: var(--fnt-bold);
+  color: red;
+  margin: 10px 0;
+`;
+
+export default StyledAlert;

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import uniqid from 'uniqid';
 import propTypes from 'prop-types';

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -9,10 +9,15 @@ import dropDownDarkSrc from './drop-down-arrow-light-icon.svg';
 import StyledSelection from './Selection.jsx';
 
 function SelectionContainer({
-  className, qtyArr, id, inStock,
+  className, qtyArr, id, inStock, clickHandler,
 }) {
   return (
-    <select className={className} id={id} disabled={!inStock}>
+    <select
+      className={className}
+      id={id}
+      disabled={!inStock}
+      onChange={(e) => clickHandler(e.target.value)}
+    >
       {qtyArr.length === 0
       && <StyledSelection key={uniqid()} text=" - " disabled={false} hidden={false} />}
       {qtyArr.length > 0
@@ -53,6 +58,7 @@ SelectionContainer.propTypes = {
   qtyArr: propTypes.arrayOf(propTypes.string).isRequired,
   id: propTypes.string.isRequired,
   inStock: propTypes.bool.isRequired,
+  clickHandler: propTypes.func.isRequired,
 };
 
 /**
@@ -66,7 +72,7 @@ SelectionContainer.propTypes = {
  *  this is done by design per the Business requirements.
  */
 
-function QtySelector({ qty }) {
+function QtySelector({ qty, clickHandler }) {
   const qtyArr = [];
   let newQty = qty;
   if (newQty > 15) {
@@ -81,13 +87,14 @@ function QtySelector({ qty }) {
 
   return (
     <label htmlFor="qty-selection">
-      <StyledSelectionContainer qtyArr={qtyArr} id="qty-selection" inStock={newQty > 0} />
+      <StyledSelectionContainer qtyArr={qtyArr} id="qty-selection" inStock={newQty > 0} clickHandler={clickHandler} />
     </label>
   );
 }
 
 QtySelector.propTypes = {
   qty: propTypes.number.isRequired,
+  clickHandler: propTypes.func.isRequired,
 };
 
 export default QtySelector;

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -9,18 +9,15 @@ import dropDownDarkSrc from './drop-down-arrow-light-icon.svg';
 import StyledSelection from './Selection.jsx';
 
 function SelectionContainer({
-  className, qtyArr, id, inStock, clickHandler,
+  className, qtyArr, id, inStock, clickHandler, userQty,
 }) {
-  const [selected, setSelected] = useState('');
-
   return (
     <select
       className={className}
       id={id}
       disabled={!inStock}
-      value={selected}
+      value={userQty === 0 || undefined ? '1' : userQty}
       onChange={(e) => {
-        setSelected(e.target.value);
         clickHandler(e.target.value);
       }}
     >
@@ -65,6 +62,7 @@ SelectionContainer.propTypes = {
   id: propTypes.string.isRequired,
   inStock: propTypes.bool.isRequired,
   clickHandler: propTypes.func.isRequired,
+  userQty: propTypes.string.isRequired,
 };
 
 /**
@@ -78,7 +76,7 @@ SelectionContainer.propTypes = {
  *  this is done by design per the Business requirements.
  */
 
-function QtySelector({ qty, clickHandler }) {
+function QtySelector({ qty, clickHandler, userQty }) {
   const qtyArr = [];
   let newQty = qty;
   if (newQty > 15) {
@@ -93,7 +91,7 @@ function QtySelector({ qty, clickHandler }) {
 
   return (
     <label htmlFor="qty-selection">
-      <StyledSelectionContainer qtyArr={qtyArr} id="qty-selection" inStock={newQty > 0} clickHandler={clickHandler} />
+      <StyledSelectionContainer qtyArr={qtyArr} id="qty-selection" inStock={newQty > 0} clickHandler={clickHandler} userQty={userQty} />
     </label>
   );
 }
@@ -101,6 +99,7 @@ function QtySelector({ qty, clickHandler }) {
 QtySelector.propTypes = {
   qty: propTypes.number.isRequired,
   clickHandler: propTypes.func.isRequired,
+  userQty: propTypes.string.isRequired,
 };
 
 export default QtySelector;

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -14,11 +14,12 @@ function SelectionContainer({
   return (
     <select className={className} id={id} disabled={!inStock}>
       {qtyArr.length === 0
-      && <StyledSelection key={uniqid()} value=" - " disabled={false} hidden={false} />}
+      && <StyledSelection key={uniqid()} text=" - " disabled={false} hidden={false} />}
       {qtyArr.length > 0
       && qtyArr.map((strNum) => (
         <StyledSelection
           key={uniqid()}
+          text={strNum}
           value={strNum}
           disabled={false}
           hidden={false}

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -34,7 +34,7 @@ const StyledSelectionContainer = styled(SelectionContainer)`
   font-size: 1.2rem;
   display: block;
   height: 65px;
-  min-width: 300px;  // remove this at some point
+  min-width: 150px;
   padding: 0 10px;
   text-transform: uppercase;
   appearance: none;

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import styled from 'styled-components';
+import uniqid from 'uniqid';
+import propTypes from 'prop-types';
+import dropDownSrc from './drop-down-arrow-icon.svg';
+import dropDownDarkSrc from './drop-down-arrow-light-icon.svg';
+
+// Components
+import StyledSelection from './Selection.jsx';
+
+function SelectionContainer({
+  className, qtyArr, id, inStock,
+}) {
+  return (
+    <select className={className} id={id} disabled={!inStock}>
+      {qtyArr.length === 0
+      && <StyledSelection key={uniqid()} value=" - " disabled={false} hidden={false} />}
+      {qtyArr.length > 0
+      && qtyArr.map((strNum) => (
+        <StyledSelection
+          key={uniqid()}
+          value={strNum}
+          disabled={false}
+          hidden={false}
+        />
+      )) }
+    </select>
+  );
+}
+
+const StyledSelectionContainer = styled(SelectionContainer)`
+  display: flex;
+  font-family: var(--fnt-bold);
+  font-size: 1.2rem;
+  display: block;
+  height: 65px;
+  min-width: 300px;  // remove this at some point
+  padding: 0 10px;
+  text-transform: uppercase;
+  appearance: none;
+  background: url("${dropDownSrc}");
+  ${({ inStock }) => (!inStock ? `background: url("${dropDownDarkSrc}");` : '')}
+  background-repeat: no-repeat;
+  background-position: calc(100% - 10px);
+  overflow: hidden;
+  background-size: 15px 15px;
+  cursor: pointer;
+`;
+
+SelectionContainer.propTypes = {
+  className: propTypes.string.isRequired,
+  qtyArr: propTypes.arrayOf(propTypes.string).isRequired,
+  id: propTypes.string.isRequired,
+  inStock: propTypes.bool.isRequired,
+};
+
+/**
+ * Properties
+ *
+ * qty: (integer)
+ *   - a integer value that specifies the qty of the product that's available.
+ *   - a decimal value is not allowed.
+ *
+ *  Note: When a value greater then 15 is input, a value up to 15 is shown.
+ *  this is done by design per the Business requirements.
+ */
+
+function QtySelector({ qty }) {
+  const qtyArr = [];
+  let newQty = qty;
+  if (newQty > 15) {
+    newQty = 15;
+  }
+
+  if (newQty !== undefined) {
+    for (let i = 0; i < newQty; i++) {
+      qtyArr.push(String(i + 1));
+    }
+  }
+
+  return (
+    <label htmlFor="qty-selection">
+      <StyledSelectionContainer qtyArr={qtyArr} id="qty-selection" inStock={newQty > 0} />
+    </label>
+  );
+}
+
+QtySelector.propTypes = {
+  qty: propTypes.number.isRequired,
+};
+
+export default QtySelector;

--- a/react-client/src/components/Overview/AddToCart/QtySelector.jsx
+++ b/react-client/src/components/Overview/AddToCart/QtySelector.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import uniqid from 'uniqid';
 import propTypes from 'prop-types';
@@ -11,12 +11,18 @@ import StyledSelection from './Selection.jsx';
 function SelectionContainer({
   className, qtyArr, id, inStock, clickHandler,
 }) {
+  const [selected, setSelected] = useState('');
+
   return (
     <select
       className={className}
       id={id}
       disabled={!inStock}
-      onChange={(e) => clickHandler(e.target.value)}
+      value={selected}
+      onChange={(e) => {
+        setSelected(e.target.value);
+        clickHandler(e.target.value);
+      }}
     >
       {qtyArr.length === 0
       && <StyledSelection key={uniqid()} text=" - " disabled={false} hidden={false} />}

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -20,7 +20,7 @@ function SelectionContainer({
       disabled={!inStock}
       value={selected}
       onChange={(e) => {
-        clickHandler(e.target.value);
+        clickHandler(e);
         setSelected(e.target.value);
       }}
     >

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import uniqid from 'uniqid';
 import propTypes from 'prop-types';
@@ -11,12 +11,18 @@ import StyledSelection from './Selection.jsx';
 function SelectionContainer({
   className, selections, name, inStock, clickHandler,
 }) {
+  const [selected, setSelected] = useState('');
+
   return (
     <select
       className={className}
       id={name}
       disabled={!inStock}
-      onClick={(e) => clickHandler(e.target.value)}
+      value={selected}
+      onChange={(e) => {
+        clickHandler(e.target.value);
+        setSelected(e.target.value);
+      }}
     >
       {!inStock && <StyledSelection text="Out of Stock" disabled={false} />}
 

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -35,9 +35,8 @@ const StyledSelectionContainer = styled(SelectionContainer)`
   display: flex;
   font-family: var(--fnt-bold);
   font-size: 1.2rem;
-  display: block;
   height: 65px;
-  min-width: 300px;  // remove this at some point
+  width: 100%;
   padding: 0 10px;
   text-transform: uppercase;
   appearance: none;
@@ -71,17 +70,18 @@ SelectionContainer.propTypes = {
  *     - stock: (number) - the amount of items in stock for the current value.
  */
 
-function SelectSize({ selections }) {
+function SelectSize({ className, selections }) {
   const inStock = selections.some((item) => item.stock > 0);
 
   return (
-    <label htmlFor="size-selection">
+    <label className={className} htmlFor="size-selection">
       <StyledSelectionContainer selections={selections} name="size-selection" inStock={inStock} />
     </label>
   );
 }
 
 SelectSize.propTypes = {
+  className: propTypes.string.isRequired,
   selections: propTypes.arrayOf(propTypes.shape({
     id: propTypes.string.isRequired,
     value: propTypes.string.isRequired,
@@ -89,4 +89,9 @@ SelectSize.propTypes = {
   })).isRequired,
 };
 
-export default SelectSize;
+const StyledSelectSize = styled(SelectSize)`
+  width: 220px;  // remove this at some point
+  flex-grow: 1;
+`;
+
+export default StyledSelectSize;

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -61,6 +61,16 @@ SelectionContainer.propTypes = {
   inStock: propTypes.bool.isRequired,
 };
 
+/**
+ * Properties
+ *
+ * selections: (array)
+ *   - An array of objects with the following properties needed per object.
+ *     - id: (string) - a unique identifier.
+ *     - value: (string) - the option that you want to appear in drop down (s, m, l, etc.).
+ *     - stock: (number) - the amount of items in stock for the current value.
+ */
+
 function StyledSelectSize({ selections }) {
   const inStock = selections.some((item) => item.stock > 0);
 

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -71,7 +71,7 @@ SelectionContainer.propTypes = {
  *     - stock: (number) - the amount of items in stock for the current value.
  */
 
-function StyledSelectSize({ selections }) {
+function SelectSize({ selections }) {
   const inStock = selections.some((item) => item.stock > 0);
 
   return (
@@ -81,7 +81,7 @@ function StyledSelectSize({ selections }) {
   );
 }
 
-StyledSelectSize.propTypes = {
+SelectSize.propTypes = {
   selections: propTypes.arrayOf(propTypes.shape({
     id: propTypes.string.isRequired,
     value: propTypes.string.isRequired,
@@ -89,4 +89,4 @@ StyledSelectSize.propTypes = {
   })).isRequired,
 };
 
-export default StyledSelectSize;
+export default SelectSize;

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -2,47 +2,36 @@ import React from 'react';
 import styled from 'styled-components';
 import uniqid from 'uniqid';
 import propTypes from 'prop-types';
-import dropDownIconSrc from './drop-down-arrow-icon.svg';
+import dropDownSrc from './drop-down-arrow-icon.svg';
+import dropDownDarkSrc from './drop-down-arrow-light-icon.svg';
 
-function Selection({
-  className, value, disabled,
+// Components
+import StyledSelection from './Selection.jsx';
+
+function SelectionContainer({
+  className, selections, name, inStock,
 }) {
-  return <option disabled={disabled} className={className} value={value.toLowerCase().replace(' ', '-')}>{value}</option>;
-}
-
-Selection.propTypes = {
-  className: propTypes.string.isRequired,
-  value: propTypes.string.isRequired,
-  disabled: propTypes.bool.isRequired,
-};
-
-const StyledSelection = styled(Selection)`
-  ${({ hidden }) => (hidden ? 'display: none;' : '')}
-  font-family: var(--fnt-regular);
-`;
-
-function SelectSize({ className, selections }) {
   return (
-    <label htmlFor="size-selection">
-      <select className={className} name="size-select" id="size-selection">
-        <StyledSelection value="Select Size" disabled={false} hidden />
-        {selections.map((item) => {
-          const isOutOfStock = item.stock === 0;
-          return (
-            <StyledSelection
-              key={uniqid()}
-              value={item.value}
-              disabled={isOutOfStock}
-              hidden={isOutOfStock}
-            />
-          );
-        })}
-      </select>
-    </label>
+    <select className={className} name={name} id="size-selection" disabled={!inStock}>
+      {!inStock && <StyledSelection value="Out of Stock" disabled={false} />}
+
+      {inStock && <StyledSelection value="Select Size" disabled={false} hidden />}
+      {inStock && selections.map((item) => {
+        const isOutOfStock = item.stock === 0;
+        return (
+          <StyledSelection
+            key={uniqid()}
+            value={item.value}
+            disabled={isOutOfStock}
+            hidden={isOutOfStock}
+          />
+        );
+      })}
+    </select>
   );
 }
 
-const StyledSelectSize = styled(SelectSize)`
+const StyledSelectionContainer = styled(SelectionContainer)`
   display: flex;
   font-family: var(--fnt-bold);
   font-size: 1.2rem;
@@ -52,7 +41,8 @@ const StyledSelectSize = styled(SelectSize)`
   padding: 0 10px;
   text-transform: uppercase;
   appearance: none;
-  background: url("${dropDownIconSrc}");
+  background: url("${dropDownSrc}");
+  ${({ inStock }) => (!inStock ? `background: url("${dropDownDarkSrc}");` : '')}
   background-repeat: no-repeat;
   background-position: calc(100% - 10px);
   overflow: hidden;
@@ -60,8 +50,28 @@ const StyledSelectSize = styled(SelectSize)`
   cursor: pointer;
 `;
 
-SelectSize.propTypes = {
+SelectionContainer.propTypes = {
   className: propTypes.string.isRequired,
+  selections: propTypes.arrayOf(propTypes.shape({
+    id: propTypes.string.isRequired,
+    value: propTypes.string.isRequired,
+    stock: propTypes.number.isRequired,
+  })).isRequired,
+  name: propTypes.string.isRequired,
+  inStock: propTypes.bool.isRequired,
+};
+
+function StyledSelectSize({ selections }) {
+  const inStock = selections.some((item) => item.stock > 0);
+
+  return (
+    <label htmlFor="size-selection">
+      <StyledSelectionContainer selections={selections} name="size-selection" inStock={inStock} />
+    </label>
+  );
+}
+
+StyledSelectSize.propTypes = {
   selections: propTypes.arrayOf(propTypes.shape({
     id: propTypes.string.isRequired,
     value: propTypes.string.isRequired,

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -12,7 +12,7 @@ function SelectionContainer({
   className, selections, name, inStock,
 }) {
   return (
-    <select className={className} name={name} id="size-selection" disabled={!inStock}>
+    <select className={className} id={name} disabled={!inStock}>
       {!inStock && <StyledSelection value="Out of Stock" disabled={false} />}
 
       {inStock && <StyledSelection value="Select Size" disabled={false} hidden />}

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -9,19 +9,25 @@ import dropDownDarkSrc from './drop-down-arrow-light-icon.svg';
 import StyledSelection from './Selection.jsx';
 
 function SelectionContainer({
-  className, selections, name, inStock,
+  className, selections, name, inStock, clickHandler,
 }) {
   return (
-    <select className={className} id={name} disabled={!inStock}>
-      {!inStock && <StyledSelection value="Out of Stock" disabled={false} />}
+    <select
+      className={className}
+      id={name}
+      disabled={!inStock}
+      onClick={(e) => clickHandler(e.target.value)}
+    >
+      {!inStock && <StyledSelection text="Out of Stock" disabled={false} />}
 
-      {inStock && <StyledSelection value="Select Size" disabled={false} hidden />}
+      {inStock && <StyledSelection text="Select Size" disabled={false} hidden />}
       {inStock && selections.map((item) => {
         const isOutOfStock = item.stock === 0;
         return (
           <StyledSelection
             key={uniqid()}
-            value={item.value}
+            value={item.id}
+            text={item.value}
             disabled={isOutOfStock}
             hidden={isOutOfStock}
           />
@@ -58,6 +64,7 @@ SelectionContainer.propTypes = {
   })).isRequired,
   name: propTypes.string.isRequired,
   inStock: propTypes.bool.isRequired,
+  clickHandler: propTypes.func.isRequired,
 };
 
 /**
@@ -70,12 +77,12 @@ SelectionContainer.propTypes = {
  *     - stock: (number) - the amount of items in stock for the current value.
  */
 
-function SelectSize({ className, selections }) {
+function SelectSize({ className, selections, selectHandler }) {
   const inStock = selections.some((item) => item.stock > 0);
 
   return (
     <label className={className} htmlFor="size-selection">
-      <StyledSelectionContainer selections={selections} name="size-selection" inStock={inStock} />
+      <StyledSelectionContainer selections={selections} name="size-selection" inStock={inStock} clickHandler={selectHandler} />
     </label>
   );
 }
@@ -87,6 +94,7 @@ SelectSize.propTypes = {
     value: propTypes.string.isRequired,
     stock: propTypes.number.isRequired,
   })).isRequired,
+  selectHandler: propTypes.func.isRequired,
 };
 
 const StyledSelectSize = styled(SelectSize)`

--- a/react-client/src/components/Overview/AddToCart/SelectSize.jsx
+++ b/react-client/src/components/Overview/AddToCart/SelectSize.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from 'styled-components';
+import uniqid from 'uniqid';
+import propTypes from 'prop-types';
+import dropDownIconSrc from './drop-down-arrow-icon.svg';
+
+function Selection({
+  className, value, disabled,
+}) {
+  return <option disabled={disabled} className={className} value={value.toLowerCase().replace(' ', '-')}>{value}</option>;
+}
+
+Selection.propTypes = {
+  className: propTypes.string.isRequired,
+  value: propTypes.string.isRequired,
+  disabled: propTypes.bool.isRequired,
+};
+
+const StyledSelection = styled(Selection)`
+  ${({ hidden }) => (hidden ? 'display: none;' : '')}
+  font-family: var(--fnt-regular);
+`;
+
+function SelectSize({ className, selections }) {
+  return (
+    <label htmlFor="size-selection">
+      <select className={className} name="size-select" id="size-selection">
+        <StyledSelection value="Select Size" disabled={false} hidden />
+        {selections.map((item) => {
+          const isOutOfStock = item.stock === 0;
+          return (
+            <StyledSelection
+              key={uniqid()}
+              value={item.value}
+              disabled={isOutOfStock}
+              hidden={isOutOfStock}
+            />
+          );
+        })}
+      </select>
+    </label>
+  );
+}
+
+const StyledSelectSize = styled(SelectSize)`
+  display: flex;
+  font-family: var(--fnt-bold);
+  font-size: 1.2rem;
+  display: block;
+  height: 65px;
+  min-width: 300px;  // remove this at some point
+  padding: 0 10px;
+  text-transform: uppercase;
+  appearance: none;
+  background: url("${dropDownIconSrc}");
+  background-repeat: no-repeat;
+  background-position: calc(100% - 10px);
+  overflow: hidden;
+  background-size: 15px 15px;
+  cursor: pointer;
+`;
+
+SelectSize.propTypes = {
+  className: propTypes.string.isRequired,
+  selections: propTypes.arrayOf(propTypes.shape({
+    id: propTypes.string.isRequired,
+    value: propTypes.string.isRequired,
+    stock: propTypes.number.isRequired,
+  })).isRequired,
+};
+
+export default StyledSelectSize;

--- a/react-client/src/components/Overview/AddToCart/Selection.jsx
+++ b/react-client/src/components/Overview/AddToCart/Selection.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+function Selection({
+  className, value, disabled,
+}) {
+  return <option disabled={disabled} className={className} value={value.toLowerCase().replace(' ', '-')}>{value}</option>;
+}
+
+Selection.propTypes = {
+  className: propTypes.string.isRequired,
+  value: propTypes.string.isRequired,
+  disabled: propTypes.bool.isRequired,
+};
+
+const StyledSelection = styled(Selection)`
+  display: block;
+  ${({ hidden }) => (hidden ? 'display: none;' : '')}
+  font-family: var(--fnt-regular);
+`;
+
+export default StyledSelection;

--- a/react-client/src/components/Overview/AddToCart/Selection.jsx
+++ b/react-client/src/components/Overview/AddToCart/Selection.jsx
@@ -3,15 +3,34 @@ import styled from 'styled-components';
 import propTypes from 'prop-types';
 
 function Selection({
-  className, value, disabled,
+  className, value, text, disabled, clickHandler,
 }) {
-  return <option disabled={disabled} className={className} value={value.toLowerCase().replace(' ', '-')}>{value}</option>;
+  return (
+    <option
+      onChange={clickHandler}
+      disabled={disabled}
+      className={className}
+      value={value}
+    >
+      {text}
+    </option>
+  );
 }
+
+Selection.defaultProps = {
+  clickHandler: () => console.log('this is a default'),
+};
+
+Selection.defaultProps = {
+  value: '',
+};
 
 Selection.propTypes = {
   className: propTypes.string.isRequired,
-  value: propTypes.string.isRequired,
+  value: propTypes.string,
+  text: propTypes.string.isRequired,
   disabled: propTypes.bool.isRequired,
+  clickHandler: propTypes.func,
 };
 
 const StyledSelection = styled(Selection)`

--- a/react-client/src/components/Overview/AddToCart/drop-down-arrow-icon.svg
+++ b/react-client/src/components/Overview/AddToCart/drop-down-arrow-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 7.33l2.829-2.83 9.175 9.339 9.167-9.339 2.829 2.83-11.996 12.17z"/></svg>

--- a/react-client/src/components/Overview/AddToCart/drop-down-arrow-light-icon.svg
+++ b/react-client/src/components/Overview/AddToCart/drop-down-arrow-light-icon.svg
@@ -1,0 +1,1 @@
+<svg opacity="0.3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 7.33l2.829-2.83 9.175 9.339 9.167-9.339 2.829 2.83-11.996 12.17z"/></svg>

--- a/react-client/src/components/Overview/AddToCart/plus-sign-icon.svg
+++ b/react-client/src/components/Overview/AddToCart/plus-sign-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M24 10h-10v-10h-4v10h-10v4h10v10h4v-10h10z"/></svg>

--- a/react-client/src/styles/main.css
+++ b/react-client/src/styles/main.css
@@ -33,6 +33,7 @@
 
   /* Colors */
   --clr-white: #FFFFFF;
+  --clr-light-grey: rgb(133, 133, 133);
 }
 
 body {


### PR DESCRIPTION
Lots of changes, to summarize.

The components in this PR include:

* SizeSelector
* QtySelector
* AddToCartBtn
* Alert
* AddToCartContainer - (which is just a container for all the above components. It has the logic that links all the above together.)

Take a look at the propTypes for AddToCartContainer. It's really the only thing thats going to take props from the API. The AddToCartContainer will filter and funnel props into there respective components.

Let me know if you have any questions or thoughts.

Small update - the inputs that the components need may not work with api inputs - but I'll make another pr at some point that will fix that. Shouldn't be much changes.