### PR TITLE
Feat/overview/imagegallery

### DIFF
--- a/react-client/src/components/Overview/ImageGallery/CloseBtn.jsx
+++ b/react-client/src/components/Overview/ImageGallery/CloseBtn.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+function CloseBtn({ className, clickHandler }) {
+  return (
+    <svg
+      onClick={() => clickHandler()}
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M23.954 21.03l-9.184-9.095 9.092-9.174-2.832-2.807-9.09 9.179-9.176-9.088-2.81 2.81 9.186 9.105-9.095 9.184 2.81 2.81 9.112-9.192 9.18 9.1z"
+      />
+    </svg>
+  );
+}
+
+const StyledCloseBtn = styled(CloseBtn)`
+  cursor: pointer;
+`;
+
+CloseBtn.propTypes = {
+  className: propTypes.string.isRequired,
+  clickHandler: propTypes.func.isRequired,
+};
+
+export default StyledCloseBtn;

--- a/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
@@ -3,12 +3,17 @@ import styled from 'styled-components';
 import propTypes from 'prop-types';
 
 const StyledInput = styled.input`
-  position: absolute;
   box-sizing: border-box;
   object-fit: cover;
-  width: 60%;
   box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
   cursor: zoom-in;
+  width: 100%;
+`;
+
+const StyledContainer = styled.div`
+  position: absolute;
+  width: 60%;
+  overflow: hidden;
 `;
 
 function ExpandedImage({
@@ -16,7 +21,9 @@ function ExpandedImage({
 }) {
   return (
     <div className={className}>
-      <StyledInput type="image" src={src} alt={alt} onClick={() => clickHandler()} />
+      <StyledContainer>
+        <StyledInput type="image" src={src} alt={alt} onClick={() => clickHandler()} />
+      </StyledContainer>
     </div>
   );
 }

--- a/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, createRef } from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
 
@@ -6,23 +6,66 @@ const StyledInput = styled.input`
   width: 100%;
   object-fit: cover;
   cursor: zoom-in;
+  ${({ isScaled }) => isScaled && 'cursor: crosshair;'}
+  ${({ isScaled }) => isScaled && 'transform: scale(3);'}
+  transform-origin: ${({ isScaled, x, y }) => isScaled && `${x}% ${y}%`};
+  transition: 1s all;
 `;
 
 const StyledContainer = styled.div`
   display: flex;
   position: absolute;
   width: 60%;
+  ${({ isScaled }) => isScaled && 'width: 70%;'}
   box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
   overflow: hidden;
+  transition: all 1s;
 `;
 
 function ExpandedImage({
   className, src, alt, clickHandler,
 }) {
+  const [isScaled, setIsScaled] = useState(false);
+  const [xAxis, setXAxis] = useState(0);
+  const [yAxis, setYAxis] = useState(0);
+  const node = createRef();
+
   return (
     <div className={className}>
-      <StyledContainer>
-        <StyledInput type="image" src={src} alt={alt} onClick={() => clickHandler()} />
+      <StyledContainer
+        ref={node}
+        isScaled={isScaled}
+        xAxis={xAxis}
+        yAxis={yAxis}
+        onMouseMove={(e) => {
+          if (isScaled) {
+            const data = node.current.getBoundingClientRect();
+
+            const offsetX = e.nativeEvent.layerX;
+            const offsetY = e.nativeEvent.layerY;
+            const xPercent = Math.ceil(((offsetX / data.width) * 100));
+            const yPercent = Math.ceil((offsetY / data.height) * 100);
+            setXAxis(xPercent);
+            setYAxis(yPercent);
+          }
+        }}
+      >
+        <StyledInput
+          isScaled={isScaled}
+          type="image"
+          x={xAxis}
+          y={yAxis}
+          src={src}
+          alt={alt}
+          onClick={() => {
+            if (!isScaled) {
+              setIsScaled(true);
+            } else {
+              setIsScaled(false);
+              clickHandler();
+            }
+          }}
+        />
       </StyledContainer>
     </div>
   );

--- a/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
@@ -6,17 +6,17 @@ const StyledInput = styled.input`
   position: absolute;
   box-sizing: border-box;
   object-fit: cover;
-  width: 70%;
+  width: 60%;
   box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
-  cursor: zoom-out;
+  cursor: zoom-in;
 `;
 
 function ExpandedImage({
   className, src, alt, clickHandler,
 }) {
   return (
-    <div tabIndex="0" role="button" className={className} onClick={() => clickHandler()} onKeyDown={() => clickHandler()}>
-      <StyledInput id="expanded-img" type="image" src={src} alt={alt} />
+    <div className={className}>
+      <StyledInput type="image" src={src} alt={alt} onClick={() => clickHandler()} />
     </div>
   );
 }
@@ -29,26 +29,13 @@ ExpandedImage.propTypes = {
 };
 
 const StyledExpandedImage = styled(ExpandedImage)`
-  z-index: 999;
-  visibility: hidden;
-  opacity: 0;
   width: 100%;
-  ${({ visible, width }) => visible && `
-  visibility: visible;
-  opacity: 1;
-  width: ${width}px;
-  `}
   position: absolute;
-  top: 0;
-  left: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
   height: 100%;
-  transition: all .4s;
-  cursor: zoom-out;
-  background-color: var(--clr-soft-peach);
 `;
 
 export default StyledExpandedImage;

--- a/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
@@ -8,7 +8,7 @@ const StyledInput = styled.input`
   cursor: zoom-in;
   ${({ isScaled }) => isScaled && 'cursor: crosshair;'}
   ${({ isScaled }) => isScaled && 'transform: scale(3);'}
-  transform-origin: ${({ isScaled, x, y }) => isScaled && `${x}% ${y}%`};
+  // transform-origin: ${({ isScaled, x, y }) => isScaled && `${x}% ${y}%`};
   transition: 1s all;
 `;
 
@@ -23,9 +23,8 @@ const StyledContainer = styled.div`
 `;
 
 function ExpandedImage({
-  className, src, alt, clickHandler,
+  className, src, alt, clickHandler, isScaled, setIsScaled,
 }) {
-  const [isScaled, setIsScaled] = useState(false);
   const [xAxis, setXAxis] = useState(0);
   const [yAxis, setYAxis] = useState(0);
   const node = createRef();
@@ -51,6 +50,7 @@ function ExpandedImage({
         }}
       >
         <StyledInput
+          style={{ transformOrigin: `${xAxis}% ${yAxis}%` }}
           isScaled={isScaled}
           type="image"
           x={xAxis}
@@ -76,6 +76,8 @@ ExpandedImage.propTypes = {
   src: propTypes.string.isRequired,
   alt: propTypes.string.isRequired,
   clickHandler: propTypes.func.isRequired,
+  isScaled: propTypes.bool.isRequired,
+  setIsScaled: propTypes.func.isRequired,
 };
 
 const StyledExpandedImage = styled(ExpandedImage)`

--- a/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
@@ -6,7 +6,7 @@ const StyledInput = styled.input`
   position: absolute;
   box-sizing: border-box;
   object-fit: cover;
-  width: 80%;
+  width: 70%;
   box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
   cursor: zoom-out;
 `;
@@ -32,9 +32,11 @@ const StyledExpandedImage = styled(ExpandedImage)`
   z-index: 999;
   visibility: hidden;
   opacity: 0;
-  ${({ visible }) => visible && `
+  width: 100%;
+  ${({ visible, width }) => visible && `
   visibility: visible;
   opacity: 1;
+  width: ${width}px;
   `}
   position: absolute;
   top: 0;
@@ -43,12 +45,10 @@ const StyledExpandedImage = styled(ExpandedImage)`
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, .5);
   transition: all .4s;
   cursor: zoom-out;
-  backdrop-filter: blur(10px);
+  background-color: var(--clr-soft-peach);
 `;
 
 export default StyledExpandedImage;

--- a/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedImage.jsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
 
 const StyledInput = styled.input`
-  box-sizing: border-box;
-  object-fit: cover;
-  box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
-  cursor: zoom-in;
   width: 100%;
+  object-fit: cover;
+  cursor: zoom-in;
 `;
 
 const StyledContainer = styled.div`
+  display: flex;
   position: absolute;
   width: 60%;
+  box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
   overflow: hidden;
 `;
 

--- a/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
@@ -9,6 +9,7 @@ import { GalleryContext } from './ImageGalleryContext';
 import StyledExpandedImage from './ExpandedImage';
 import { StyledLeftArrow, StyledRightArrow } from './Arrows';
 import StyledAnimateImg from './AnimateImg';
+import StyledIconList from './IconList';
 
 const ArrowContainer = styled.div`
   position: absolute;
@@ -23,10 +24,17 @@ const RightArrowContainer = styled(ArrowContainer)`
   right: 0;
 `;
 
+const IconListContainer = styled.div`
+  position: absolute;
+  bottom: 50px;
+  z-index: 999;
+`;
+
 function ExpandedView({ className }) {
   const {
     imgsArr,
     currImg,
+    setCurrImg,
     goToNextImg,
     goToPrevImg,
     setExpandedViewVisible,
@@ -51,6 +59,13 @@ function ExpandedView({ className }) {
       <RightArrowContainer>
         <StyledRightArrow isVisible={!lastImgIsSelected()} clickHandler={() => goToNextImg()} />
       </RightArrowContainer>
+      <IconListContainer>
+        <StyledIconList
+          imgs={imgsArr}
+          selectedImg={currImg}
+          setSelectedImg={(img) => setCurrImg(img)}
+        />
+      </IconListContainer>
     </div>
   );
 }

--- a/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+// Components
+import StyledExpandedImage from './ExpandedImage';
+import { StyledLeftArrow, StyledRightArrow } from './Arrows';
+
+const ArrowContainer = styled.div`
+  position: absolute;
+  margin: 50px;
+`;
+
+const LeftArrowContainer = styled(ArrowContainer)`
+  left: 0;
+`;
+
+const RightArrowContainer = styled(ArrowContainer)`
+  right: 0;
+`;
+
+function ExpandedView({
+  className, img, clickHandler, goToNextImg, goToPrevImg,
+}) {
+  return (
+    <div className={className}>
+      <LeftArrowContainer>
+        <StyledLeftArrow isVisible clickHandler={() => goToPrevImg()} />
+      </LeftArrowContainer>
+      <StyledExpandedImage
+        src={img.url}
+        alt="#"
+        clickHandler={() => clickHandler()}
+      />
+      <RightArrowContainer>
+        <StyledRightArrow isVisible clickHandler={() => goToNextImg()} />
+      </RightArrowContainer>
+    </div>
+  );
+}
+
+ExpandedView.propTypes = {
+  className: propTypes.string.isRequired,
+  img: propTypes.shape({
+    id: propTypes.string.isRequired,
+    url: propTypes.string.isRequired,
+    alt: propTypes.string.isRequired,
+    index: propTypes.number.isRequired,
+  }).isRequired,
+  clickHandler: propTypes.func.isRequired,
+  goToNextImg: propTypes.func.isRequired,
+  goToPrevImg: propTypes.func.isRequired,
+};
+
+const StyledExpandedView = styled(ExpandedView)`
+  z-index: 999;
+  visibility: hidden;
+  opacity: 0;
+  width: 100%;
+  ${({ isVisible, viewWidth }) => isVisible && `
+  visibility: visible;
+  opacity: 1;
+  width: ${viewWidth}px;
+  `}
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 100%;
+  transition: all .4s;
+  // background-color: red;
+  background-color: var(--clr-soft-peach);
+`;
+
+export default StyledExpandedView;

--- a/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
 
@@ -28,6 +28,13 @@ const IconListContainer = styled.div`
   position: absolute;
   bottom: 50px;
   z-index: 999;
+  visibility: visible;
+  opacity: 1;
+  ${({ isVisible }) => !isVisible && `
+  opacity: 0;
+  visibility: hidden;
+  `}
+  transition: all 1s;
 `;
 
 function ExpandedView({ className }) {
@@ -41,15 +48,21 @@ function ExpandedView({ className }) {
     firstImgIsSelected,
     lastImgIsSelected,
   } = useContext(GalleryContext);
+  const [isScaled, setIsScaled] = useState(false);
 
   return (
     <div className={className}>
       <LeftArrowContainer>
-        <StyledLeftArrow isVisible={!firstImgIsSelected()} clickHandler={() => goToPrevImg()} />
+        <StyledLeftArrow
+          isVisible={!firstImgIsSelected() && !isScaled}
+          clickHandler={() => goToPrevImg()}
+        />
       </LeftArrowContainer>
       {imgsArr.map((img) => (
         <StyledAnimateImg key={img.id} selected={currImg.id === img.id}>
           <StyledExpandedImage
+            isScaled={isScaled}
+            setIsScaled={(bool) => setIsScaled(bool)}
             src={img.url}
             alt="#"
             clickHandler={() => setExpandedViewVisible(false)}
@@ -57,9 +70,12 @@ function ExpandedView({ className }) {
         </StyledAnimateImg>
       ))}
       <RightArrowContainer>
-        <StyledRightArrow isVisible={!lastImgIsSelected()} clickHandler={() => goToNextImg()} />
+        <StyledRightArrow
+          isVisible={!lastImgIsSelected() && !isScaled}
+          clickHandler={() => goToNextImg()}
+        />
       </RightArrowContainer>
-      <IconListContainer>
+      <IconListContainer isVisible={!isScaled}>
         <StyledIconList
           imgs={imgsArr}
           selectedImg={currImg}

--- a/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
@@ -10,6 +10,7 @@ import StyledExpandedImage from './ExpandedImage';
 import { StyledLeftArrow, StyledRightArrow } from './Arrows';
 import StyledAnimateImg from './AnimateImg';
 import StyledIconList from './IconList';
+import StyledCloseBtn from './CloseBtn';
 
 const ArrowContainer = styled.div`
   position: absolute;
@@ -22,6 +23,20 @@ const LeftArrowContainer = styled(ArrowContainer)`
 
 const RightArrowContainer = styled(ArrowContainer)`
   right: 0;
+`;
+
+const CloseBtnContainer = styled.div`
+  position: absolute;
+  top: 30px;
+  right: 30px;
+  z-index: 999;
+  visibility: visible;
+  opacity: 1;
+  ${({ isVisible }) => !isVisible && `
+  opacity: 0;
+  visibility: hidden;
+  `}
+  transition: all 1s;
 `;
 
 const IconListContainer = styled.div`
@@ -52,6 +67,9 @@ function ExpandedView({ className }) {
 
   return (
     <div className={className}>
+      <CloseBtnContainer isVisible={!isScaled}>
+        <StyledCloseBtn clickHandler={() => setExpandedViewVisible(false)} />
+      </CloseBtnContainer>
       <LeftArrowContainer>
         <StyledLeftArrow
           isVisible={!firstImgIsSelected() && !isScaled}
@@ -65,7 +83,7 @@ function ExpandedView({ className }) {
             setIsScaled={(bool) => setIsScaled(bool)}
             src={img.url}
             alt="#"
-            clickHandler={() => setExpandedViewVisible(false)}
+            clickHandler={() => setIsScaled(false)}
           />
         </StyledAnimateImg>
       ))}

--- a/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ExpandedView.jsx
@@ -1,10 +1,14 @@
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
+
+// Assets
+import { GalleryContext } from './ImageGalleryContext';
 
 // Components
 import StyledExpandedImage from './ExpandedImage';
 import { StyledLeftArrow, StyledRightArrow } from './Arrows';
+import StyledAnimateImg from './AnimateImg';
 
 const ArrowContainer = styled.div`
   position: absolute;
@@ -19,21 +23,33 @@ const RightArrowContainer = styled(ArrowContainer)`
   right: 0;
 `;
 
-function ExpandedView({
-  className, img, clickHandler, goToNextImg, goToPrevImg,
-}) {
+function ExpandedView({ className }) {
+  const {
+    imgsArr,
+    currImg,
+    goToNextImg,
+    goToPrevImg,
+    setExpandedViewVisible,
+    firstImgIsSelected,
+    lastImgIsSelected,
+  } = useContext(GalleryContext);
+
   return (
     <div className={className}>
       <LeftArrowContainer>
-        <StyledLeftArrow isVisible clickHandler={() => goToPrevImg()} />
+        <StyledLeftArrow isVisible={!firstImgIsSelected()} clickHandler={() => goToPrevImg()} />
       </LeftArrowContainer>
-      <StyledExpandedImage
-        src={img.url}
-        alt="#"
-        clickHandler={() => clickHandler()}
-      />
+      {imgsArr.map((img) => (
+        <StyledAnimateImg key={img.id} selected={currImg.id === img.id}>
+          <StyledExpandedImage
+            src={img.url}
+            alt="#"
+            clickHandler={() => setExpandedViewVisible(false)}
+          />
+        </StyledAnimateImg>
+      ))}
       <RightArrowContainer>
-        <StyledRightArrow isVisible clickHandler={() => goToNextImg()} />
+        <StyledRightArrow isVisible={!lastImgIsSelected()} clickHandler={() => goToNextImg()} />
       </RightArrowContainer>
     </div>
   );
@@ -41,23 +57,15 @@ function ExpandedView({
 
 ExpandedView.propTypes = {
   className: propTypes.string.isRequired,
-  img: propTypes.shape({
-    id: propTypes.string.isRequired,
-    url: propTypes.string.isRequired,
-    alt: propTypes.string.isRequired,
-    index: propTypes.number.isRequired,
-  }).isRequired,
-  clickHandler: propTypes.func.isRequired,
-  goToNextImg: propTypes.func.isRequired,
-  goToPrevImg: propTypes.func.isRequired,
 };
 
 const StyledExpandedView = styled(ExpandedView)`
-  z-index: 999;
+  z-index: 0;
   visibility: hidden;
   opacity: 0;
   width: 100%;
   ${({ isVisible, viewWidth }) => isVisible && `
+  z-index: 999;
   visibility: visible;
   opacity: 1;
   width: ${viewWidth}px;

--- a/react-client/src/components/Overview/ImageGallery/Icon.jsx
+++ b/react-client/src/components/Overview/ImageGallery/Icon.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+function Icon({ className, clickHandler }) {
+  return (
+    <svg
+      onClick={() => clickHandler()}
+      className={className}
+      width="24"
+      height="24"
+      xmlns="http://www.w3.org/2000/svg"
+      fillRule="evenodd"
+      clipRule="evenodd"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="12"
+      />
+    </svg>
+  );
+}
+
+const StyledIcon = styled(Icon)`
+  display: flex;
+  fill: #C4C4C4;
+  ${({ selected }) => selected && 'fill: #4D4D4D;'}
+  transition: all 1s;
+  cursor: pointer;
+`;
+
+Icon.propTypes = {
+  className: propTypes.string.isRequired,
+  clickHandler: propTypes.func.isRequired,
+};
+
+export default StyledIcon;

--- a/react-client/src/components/Overview/ImageGallery/IconList.jsx
+++ b/react-client/src/components/Overview/ImageGallery/IconList.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import propTypes from 'prop-types';
+
+// Components
+import StyledIcon from './Icon';
+
+function IconList({
+  className, imgs, selectedImg, setSelectedImg,
+}) {
+  return (
+    <ul className={className}>
+      {imgs.map((img) => (
+        <li key={img.id}>
+          <StyledIcon
+            selected={selectedImg.id === img.id}
+            clickHandler={() => setSelectedImg(img)}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const StyledIconList = styled(IconList)`
+  display: flex;
+  gap: 20px;
+`;
+
+IconList.propTypes = {
+  className: propTypes.string.isRequired,
+  imgs: propTypes.arrayOf(propTypes.shape({
+    id: propTypes.string.isRequired,
+    url: propTypes.string.isRequired,
+    alt: propTypes.string.isRequired,
+    index: propTypes.number.isRequired,
+  }).isRequired).isRequired,
+  selectedImg: propTypes.shape({
+    id: propTypes.string.isRequired,
+    url: propTypes.string.isRequired,
+    alt: propTypes.string.isRequired,
+    index: propTypes.number.isRequired,
+  }).isRequired,
+  setSelectedImg: propTypes.func.isRequired,
+};
+
+export default StyledIconList;

--- a/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -107,7 +107,7 @@ const StyledImageGallery = styled(ImageGallery)`
   position: relative;
   box-sizing: border-box;
   height: 800px;
-  width: 1000px;
+  width: 900px;
   background-color: #EDEFF0;
   padding: 20px;
 `;

--- a/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
-import uniqid from 'uniqid';
 
 // Assets
-import useTracker from './ThumbnailContent/useTracker';
+import { GalleryProvider, GalleryContext } from './ImageGalleryContext';
 
 // Components
 import StyledThumbnailsContainer from './ThumbnailContent/ThumbnailsContainer';
@@ -45,49 +44,41 @@ const StyledArrowPadding = styled.div`
   ${({ right }) => right && 'margin-right: 20px;'}
 `;
 
-const updateImgsArr = (arr) => {
-  const arrCopy = arr.map((obj) => {
-    const newObj = { ...obj };
-    newObj.id = uniqid();
-    newObj.alt = '#';
-    return newObj;
-  });
+function ImageGalleryContainer({ data, expandedImgWidth }) {
+  return (
+    <GalleryProvider newData={{ data, expandedImgWidth }}>
+      <StyledImageGallery />
+    </GalleryProvider>
+  );
+}
 
-  return useTracker(arrCopy).arr;
+ImageGalleryContainer.propTypes = {
+  data: propTypes.arrayOf(propTypes.shape({
+    thumbnail_url: propTypes.string.isRequired,
+    url: propTypes.string.isRequired,
+  })).isRequired,
+  expandedImgWidth: propTypes.number.isRequired,
 };
 
-function ImageGallery({ className, data, expandedImgWidth }) {
-  const [imgsArr] = useState(updateImgsArr(data));
-  const [currImg, setCurrImg] = useState(imgsArr[0]);
-  const [expandedViewVisible, setExpandedViewVisible] = useState(false);
-
-  const goToPrevImg = () => {
-    if (currImg.index > 0) {
-      const prevImg = imgsArr[currImg.index - 1];
-      setCurrImg(prevImg);
-    }
-  };
-
-  const goToNextImg = () => {
-    if (currImg.index + 1 < imgsArr.length) {
-      const nextImg = imgsArr[currImg.index + 1];
-      setCurrImg(nextImg);
-    }
-  };
-
-  const firstImgIsSelected = () => currImg.index === 0;
-
-  const lastImgIsSelected = () => currImg.index === imgsArr.length - 1;
+function ImageGallery({ className }) {
+  const {
+    currImg,
+    setCurrImg,
+    imgsArr,
+    goToNextImg,
+    goToPrevImg,
+    expandedViewVisible,
+    setExpandedViewVisible,
+    firstImgIsSelected,
+    lastImgIsSelected,
+    expandedImgWidth,
+  } = useContext(GalleryContext);
 
   return (
     <div className={className}>
       <StyledExpandedView
-        img={currImg}
-        clickHandler={() => setExpandedViewVisible(false)}
         isVisible={expandedViewVisible}
         viewWidth={expandedImgWidth}
-        goToNextImg={() => goToNextImg()}
-        goToPrevImg={() => goToPrevImg()}
       />
       <StyledContainer>
         <LeftDiv>
@@ -138,11 +129,6 @@ const StyledImageGallery = styled(ImageGallery)`
 
 ImageGallery.propTypes = {
   className: propTypes.string.isRequired,
-  data: propTypes.arrayOf(propTypes.shape({
-    thumbnail_url: propTypes.string.isRequired,
-    url: propTypes.string.isRequired,
-  })).isRequired,
-  expandedImgWidth: propTypes.number.isRequired,
 };
 
-export default StyledImageGallery;
+export default ImageGalleryContainer;

--- a/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -7,11 +7,11 @@ import uniqid from 'uniqid';
 import useTracker from './ThumbnailContent/useTracker';
 
 // Components
-import StyledThumbnailsContainer from './ThumbnailContent/ThumbnailsContainer.jsx';
-import StyledMainImage from './MainImage.jsx';
-import StyledExpandedImage from './ExpandedImage.jsx';
-import StyledAnimateImg from './AnimateImg.jsx';
-import { StyledLeftArrow, StyledRightArrow } from './Arrows.jsx';
+import StyledThumbnailsContainer from './ThumbnailContent/ThumbnailsContainer';
+import StyledMainImage from './MainImage';
+import StyledExpandedImage from './ExpandedImage';
+import StyledAnimateImg from './AnimateImg';
+import { StyledLeftArrow, StyledRightArrow } from './Arrows';
 
 const StyledContainer = styled.div`
   display: flex;
@@ -48,7 +48,7 @@ const updateImgsArr = (arr) => {
   return useTracker(arrCopy).arr;
 };
 
-function ImageGallery({ className, data }) {
+function ImageGallery({ className, data, expandedImgWidth }) {
   const [imgsArr] = useState(updateImgsArr(data));
   const [currImg, setCurrImg] = useState(imgsArr[0]);
   const [expandedViewVisible, setExpandedViewVisible] = useState(false);
@@ -69,7 +69,13 @@ function ImageGallery({ className, data }) {
 
   return (
     <div className={className}>
-      <StyledExpandedImage src={currImg.url} alt="#" clickHandler={() => setExpandedViewVisible(false)} visible={expandedViewVisible} />
+      <StyledExpandedImage
+        src={currImg.url}
+        alt="#"
+        clickHandler={() => setExpandedViewVisible(false)}
+        visible={expandedViewVisible}
+        width={expandedImgWidth}
+      />
       <StyledContainer>
         <LeftDiv>
           <StyledThumbnailsContainer
@@ -118,6 +124,7 @@ ImageGallery.propTypes = {
     thumbnail_url: propTypes.string.isRequired,
     url: propTypes.string.isRequired,
   })).isRequired,
+  expandedImgWidth: propTypes.number.isRequired,
 };
 
 export default StyledImageGallery;

--- a/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -21,6 +21,7 @@ const StyledContainer = styled.div`
 `;
 
 const LeftDiv = styled.div`
+  z-index: 2;
 `;
 
 const RightDiv = styled.div`
@@ -30,6 +31,13 @@ const RightDiv = styled.div`
   position: relative;
   width: 100%;
   overflow: hidden;
+`;
+
+const ImgContainer = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
 `;
 
 const StyledArrowPadding = styled.div`
@@ -88,21 +96,23 @@ function ImageGallery({ className, data, expandedImgWidth }) {
           <StyledArrowPadding left>
             <StyledLeftArrow isVisible={currImg.index !== 0} clickHandler={() => goToPrevImg()} />
           </StyledArrowPadding>
+          <ImgContainer>
+            {imgsArr.map((image) => (
+              <StyledAnimateImg key={image.id} selected={currImg.id === image.id}>
+                <StyledMainImage
+                  src={image.url}
+                  alt="#"
+                  clickHandler={() => setExpandedViewVisible(true)}
+                />
+              </StyledAnimateImg>
+            ))}
+          </ImgContainer>
           <StyledArrowPadding right>
             <StyledRightArrow
               isVisible={currImg.index !== imgsArr.length - 1}
               clickHandler={() => goToNextImg()}
             />
           </StyledArrowPadding>
-          {imgsArr.map((image) => (
-            <StyledAnimateImg key={image.id} selected={currImg.id === image.id}>
-              <StyledMainImage
-                src={image.url}
-                alt="#"
-                clickHandler={() => setExpandedViewVisible(true)}
-              />
-            </StyledAnimateImg>
-          ))}
         </RightDiv>
       </StyledContainer>
     </div>
@@ -114,7 +124,7 @@ const StyledImageGallery = styled(ImageGallery)`
   box-sizing: border-box;
   height: 800px;
   width: 900px;
-  background-color: #EDEFF0;
+  background-color: var(--clr-soft-peach);
   padding: 20px;
 `;
 

--- a/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
 
@@ -44,7 +44,18 @@ const StyledArrowPadding = styled.div`
   ${({ right }) => right && 'margin-right: 20px;'}
 `;
 
-function ImageGalleryContainer({ data, expandedImgWidth }) {
+const getDim = () => (window.innerWidth < 1400 ? window.innerWidth : 1400);
+
+function ImageGalleryContainer({ data }) {
+  const [expandedImgWidth, setExpandedImgWidth] = useState(getDim());
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      const dim = getDim();
+      setExpandedImgWidth(dim);
+    });
+  }, []);
+
   return (
     <GalleryProvider newData={{ data, expandedImgWidth }}>
       <StyledImageGallery />
@@ -57,7 +68,6 @@ ImageGalleryContainer.propTypes = {
     thumbnail_url: propTypes.string.isRequired,
     url: propTypes.string.isRequired,
   })).isRequired,
-  expandedImgWidth: propTypes.number.isRequired,
 };
 
 function ImageGallery({ className }) {

--- a/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -9,7 +9,7 @@ import useTracker from './ThumbnailContent/useTracker';
 // Components
 import StyledThumbnailsContainer from './ThumbnailContent/ThumbnailsContainer';
 import StyledMainImage from './MainImage';
-import StyledExpandedImage from './ExpandedImage';
+import StyledExpandedView from './ExpandedView';
 import StyledAnimateImg from './AnimateImg';
 import { StyledLeftArrow, StyledRightArrow } from './Arrows';
 
@@ -75,14 +75,19 @@ function ImageGallery({ className, data, expandedImgWidth }) {
     }
   };
 
+  const firstImgIsSelected = () => currImg.index === 0;
+
+  const lastImgIsSelected = () => currImg.index === imgsArr.length - 1;
+
   return (
     <div className={className}>
-      <StyledExpandedImage
-        src={currImg.url}
-        alt="#"
+      <StyledExpandedView
+        img={currImg}
         clickHandler={() => setExpandedViewVisible(false)}
-        visible={expandedViewVisible}
-        width={expandedImgWidth}
+        isVisible={expandedViewVisible}
+        viewWidth={expandedImgWidth}
+        goToNextImg={() => goToNextImg()}
+        goToPrevImg={() => goToPrevImg()}
       />
       <StyledContainer>
         <LeftDiv>
@@ -94,7 +99,10 @@ function ImageGallery({ className, data, expandedImgWidth }) {
         </LeftDiv>
         <RightDiv>
           <StyledArrowPadding left>
-            <StyledLeftArrow isVisible={currImg.index !== 0} clickHandler={() => goToPrevImg()} />
+            <StyledLeftArrow
+              isVisible={!firstImgIsSelected()}
+              clickHandler={() => goToPrevImg()}
+            />
           </StyledArrowPadding>
           <ImgContainer>
             {imgsArr.map((image) => (
@@ -109,7 +117,7 @@ function ImageGallery({ className, data, expandedImgWidth }) {
           </ImgContainer>
           <StyledArrowPadding right>
             <StyledRightArrow
-              isVisible={currImg.index !== imgsArr.length - 1}
+              isVisible={!lastImgIsSelected()}
               clickHandler={() => goToNextImg()}
             />
           </StyledArrowPadding>

--- a/react-client/src/components/Overview/ImageGallery/ImageGalleryContext.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGalleryContext.jsx
@@ -1,0 +1,74 @@
+import React, { createContext, useState, useMemo, useEffect } from 'react';
+import propTypes from 'prop-types';
+import uniqid from 'uniqid';
+
+// Assets
+import useTracker from './ThumbnailContent/useTracker';
+
+const GalleryContext = createContext();
+
+const updateImgsArr = (arr) => {
+  const arrCopy = arr.map((obj) => {
+    const newObj = { ...obj };
+    newObj.id = uniqid();
+    newObj.alt = '#';
+    return newObj;
+  });
+
+  return useTracker(arrCopy).arr;
+};
+
+function GalleryProvider({ children, newData }) {
+  const [imgsArr] = useState(updateImgsArr(newData.data));
+  const [currImg, setCurrImg] = useState(imgsArr[0]);
+  const [expandedViewVisible, setExpandedViewVisible] = useState(false);
+  const [expandedImgWidth] = useState(newData.expandedImgWidth);
+
+  const goToPrevImg = () => {
+    if (currImg.index > 0) {
+      const prevImg = imgsArr[currImg.index - 1];
+      setCurrImg(prevImg);
+    }
+  };
+
+  const goToNextImg = () => {
+    if (currImg.index + 1 < imgsArr.length) {
+      const nextImg = imgsArr[currImg.index + 1];
+      setCurrImg(nextImg);
+    }
+  };
+
+  const firstImgIsSelected = () => currImg.index === 0;
+
+  const lastImgIsSelected = () => currImg.index === imgsArr.length - 1;
+
+  const data = useMemo(() => ({
+    imgsArr,
+    currImg,
+    setCurrImg,
+    expandedViewVisible,
+    setExpandedViewVisible,
+    goToPrevImg,
+    goToNextImg,
+    firstImgIsSelected,
+    lastImgIsSelected,
+    expandedImgWidth,
+  }), [currImg, expandedViewVisible]);
+
+  useEffect(() => {
+    console.log(expandedViewVisible);
+  }, [expandedViewVisible]);
+
+  return (
+    <GalleryContext.Provider
+      value={data}
+    >
+      {children}
+    </GalleryContext.Provider>
+  );
+}
+
+GalleryProvider.propTypes = {
+};
+
+export { GalleryProvider, GalleryContext };

--- a/react-client/src/components/Overview/ImageGallery/ImageGalleryContext.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGalleryContext.jsx
@@ -1,5 +1,4 @@
 import React, { createContext, useState, useMemo, useEffect } from 'react';
-import propTypes from 'prop-types';
 import uniqid from 'uniqid';
 
 // Assets
@@ -56,7 +55,6 @@ function GalleryProvider({ children, newData }) {
   }), [currImg, expandedViewVisible]);
 
   useEffect(() => {
-    console.log(expandedViewVisible);
   }, [expandedViewVisible]);
 
   return (
@@ -67,8 +65,5 @@ function GalleryProvider({ children, newData }) {
     </GalleryContext.Provider>
   );
 }
-
-GalleryProvider.propTypes = {
-};
 
 export { GalleryProvider, GalleryContext };

--- a/react-client/src/components/Overview/ImageGallery/ImageGalleryContext.jsx
+++ b/react-client/src/components/Overview/ImageGallery/ImageGalleryContext.jsx
@@ -21,7 +21,7 @@ function GalleryProvider({ children, newData }) {
   const [imgsArr] = useState(updateImgsArr(newData.data));
   const [currImg, setCurrImg] = useState(imgsArr[0]);
   const [expandedViewVisible, setExpandedViewVisible] = useState(false);
-  const [expandedImgWidth] = useState(newData.expandedImgWidth);
+  const [expandedImgWidth, setExpandedImgWidth] = useState(newData.expandedImgWidth);
 
   const goToPrevImg = () => {
     if (currImg.index > 0) {
@@ -52,10 +52,13 @@ function GalleryProvider({ children, newData }) {
     firstImgIsSelected,
     lastImgIsSelected,
     expandedImgWidth,
-  }), [currImg, expandedViewVisible]);
+  }), [currImg, expandedViewVisible, expandedImgWidth]);
 
   useEffect(() => {
-  }, [expandedViewVisible]);
+    if (window.innerWidth <= 1400) {
+      setExpandedImgWidth(window.innerWidth);
+    }
+  }, [window.innerWidth]);
 
   return (
     <GalleryContext.Provider

--- a/react-client/src/components/Overview/ImageGallery/MainImage.jsx
+++ b/react-client/src/components/Overview/ImageGallery/MainImage.jsx
@@ -29,7 +29,7 @@ MainImage.propTypes = {
 };
 
 const StyledMainImage = styled(MainImage)`
-  position: absolute;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/react-client/src/styles/main.css
+++ b/react-client/src/styles/main.css
@@ -53,6 +53,7 @@
   --clr-white: #FFFFFF;
   --clr-light-grey: rgb(133, 133, 133);
   --clr-light-black: #525252;
+  --clr-soft-peach: #EDEFF0;
 }
 
 body {


### PR DESCRIPTION
This PR should only edit the image carousel and expand upon it.

What I did was extended the features in Expanded View for the carousel allowing the user to
- zoom in on an image
- have a larger view of the image they click on
- and have simliar functionalities to default view in expanded view

To test this project out, just import the `ImageGalleryContainer.jsx` from `ImageGallery.jsx` component into `Overview.jsx` and pass in this prop

- data:  (array) - pass in the variable that's in this [gist](https://gist.github.com/ec-rilo/14e510ba44cd8eea356f30e7d4e56bd4) declare the variable where you want in Overview.jsx
